### PR TITLE
Retrieve the app name in the HTML title from messages.xml

### DIFF
--- a/src/ui/FileShelterApplication.cpp
+++ b/src/ui/FileShelterApplication.cpp
@@ -161,7 +161,7 @@ FileShelterApplication::FileShelterApplication(const Wt::WEnvironment& env, Wt::
 	messageResourceBundle().use(appRoot() + "tos");
 	messageResourceBundle().use((Config::instance().getPath("working-dir") / "tos_user").string());
 
-	setTitle("FileShelter");
+	setTitle(Wt::WString::tr("msg-app-name"));
 
 	enableInternalPaths();
 


### PR DESCRIPTION
The application name in the bootstrap title bar is retrieved from `messages.xml`, and I believe the application name in the browser title bar should be the same. This patch ensures this is the case.