### PR TITLE
Fix uploading through the reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ server {
     proxy_request_buffering off;
     proxy_buffering off;
     proxy_buffer_size 4k;
+    client_max_body_size 256M; # Make the number the same as 'max-file-size' in fileshelter.conf
 
     location / {
 


### PR DESCRIPTION
Without `client_max_body_size`, uploads above 1MB will fail. This change increases the file upload size limit for nginx, fixing the issue.