### PR TITLE
Use same port as example conf in nginx example

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ server {
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
 
-      proxy_pass          http://localhost:5082;
+      proxy_pass          http://localhost:5091;
       proxy_read_timeout  120;
     }
 }


### PR DESCRIPTION
I ran into the same issue regarding different ports in the example conf file vs the nginx example in the README here: https://github.com/epoupon/fileshelter/issues/44

I think this small fix could help people avoid this in the future.