### PR TITLE
Adding /share-list url to display simple list of active shares

### DIFF
--- a/approot/messages.xml
+++ b/approot/messages.xml
@@ -31,6 +31,8 @@
 	<message id="msg-share-not-found">Share not found!</message>
 	<message id="msg-share-protected-by-password">This share is protected by a password</message>
 	<message id="msg-share-size">Share size</message>
+	<message id="msg-share-list">List of shares</message>
+	<message id="msg-share-list-protected-by-password">A password is required to access this page</message>
 	<message id="msg-size-b">{1} B</message>
 	<message id="msg-size-gb">{1} GB</message>
 	<message id="msg-size-kb">{1} KB</message>

--- a/approot/messages_de.xml
+++ b/approot/messages_de.xml
@@ -31,6 +31,8 @@
 	<message id="msg-share-not-found">Share nicht gefunden !</message>
 	<message id="msg-share-protected-by-password">Dieses Share ist durch ein Passwort geschützt</message>
 
+
+
 	<message id="msg-size-b">{1} B</message>
 	<message id="msg-size-gb">{1} GB</message>
 	<message id="msg-size-kb">{1} KB</message>

--- a/approot/messages_fr.xml
+++ b/approot/messages_fr.xml
@@ -31,6 +31,8 @@
 	<message id="msg-share-not-found">Partage non trouvé !</message>
 	<message id="msg-share-protected-by-password">Ce partage est protégé par un mot de passe</message>
 	<message id="msg-share-size">Taille</message>
+	<message id="msg-share-list">Liste des partages</message>
+	<message id="msg-share-list-protected-by-password">Un mot de passe est nécessaire pour accéder à cette page</message>
 	<message id="msg-size-b">{1} B</message>
 	<message id="msg-size-gb">{1} GB</message>
 	<message id="msg-size-kb">{1} KB</message>

--- a/approot/messages_ru.xml
+++ b/approot/messages_ru.xml
@@ -31,6 +31,8 @@
 	<message id="msg-share-not-found">Файл не найден!</message>
 	<message id="msg-share-protected-by-password">Этот файл защищен паролем !</message>
 
+
+
 	<message id="msg-size-b">{1} B</message>
 	<message id="msg-size-gb">{1} GB</message>
 	<message id="msg-size-kb">{1} KB</message>

--- a/approot/templates.xml
+++ b/approot/templates.xml
@@ -300,6 +300,67 @@
 	<h1><i class="fa fa-remove"></i> ${tr:msg-share-deleted}</h1>
 </message>
 
+<message id="template-share-list-password">
+	<h1><i class="fa fa-list"></i> ${tr:msg-share-list}</h1>
+	<div class="alert alert-info">
+		${tr:msg-share-list-protected-by-password}
+	</div>
+	<div class="form-horizontal">
+		<div class="form-group">
+			<label class="control-label col-sm-2"  for="${id:password}">
+				${tr:msg-password}
+			</label>
+			<div class="col-sm-5">
+				${password}
+			</div>
+			<div class="help-block col-sm-5">
+				${password-info}
+			</div>
+		</div>
+		<div class="form-group">
+			<div class="col-sm-offset-2 col-sm-5">
+				${unlock-btn class="btn-primary"}
+			</div>
+		</div>
+	</div>
+</message>
+
+<message id="template-share-list">
+	<h1><i class="fa fa-list"></i> ${tr:msg-share-list}</h1>
+
+	<table class="table table-striped">
+		<thead>
+			<tr>
+				<th scope="col">UUID</th>
+				<th scope="col">${tr:msg-expires}</th>
+				<th class="hidden-xs" scope="col">${tr:msg-share-size}</th>
+				<th scope="col">${tr:msg-download-count}</th>
+				<th scope="col"></th>
+			</tr>
+		</thead>
+		<tbody>
+			${shares}
+			<tr>
+				<td>${total-shares}</td>
+				<td></td>
+				<td class="fs-file-entry-size hidden-xs"></td>
+				<td></td>
+				<td></td>
+			</tr>
+		</tbody>
+	</table>
+</message>
+
+<message id="template-share-list-file">
+	<tr>
+		<td>${share-uuid}</td>
+		<td>${expiry-date-time}</td>
+		<td class="fs-file-entry-size hidden-xs">${share-size}</td>
+		<td>${download-count}</td>
+		<td>${created-by}</td>
+	</tr>
+</message>
+
 <message id="template-progress-bar">
 	<div class="progress">
 		${progress}

--- a/conf/fileshelter.conf
+++ b/conf/fileshelter.conf
@@ -31,6 +31,18 @@ upload-passwords =
 (
 );
 
+# Required password to access list of shares at /share-list.
+# If no password is set the page will not be accessible at all
+# Ex:
+# list-passwords =
+# (
+#   "password1",
+#   "password2"
+# );
+list-passwords =
+(
+);
+
 # Listen port/addr of the web server
 listen-port = 5091;
 listen-addr = "0.0.0.0";

--- a/src/fileshelter/CMakeLists.txt
+++ b/src/fileshelter/CMakeLists.txt
@@ -14,6 +14,8 @@ add_executable(fileshelter
 	ui/ShareDownload.cpp
 	ui/ShareEdit.cpp
 	ui/ShareDownloadPassword.cpp
+	ui/ShareList.cpp
+	ui/ShareListPassword.cpp
 	ui/TermsOfService.cpp
 	)
 

--- a/src/fileshelter/ui/FileShelterApplication.cpp
+++ b/src/fileshelter/ui/FileShelterApplication.cpp
@@ -37,6 +37,7 @@
 #include "ShareDownload.hpp"
 #include "ShareEdit.hpp"
 #include "TermsOfService.hpp"
+#include "ShareList.hpp"
 
 namespace UserInterface {
 
@@ -62,6 +63,7 @@ enum Idx
 	IdxShareDownload	= 2,
 	IdxShareEdit		= 3,
 	IdxToS				= 4,
+	IdxShareList		= 5,
 };
 
 static
@@ -75,6 +77,7 @@ handlePathChange(Wt::WStackedWidget* stack)
 		{ "/share-download",	IdxShareDownload },
 		{ "/share-edit",		IdxShareEdit },
 		{ "/tos",				IdxToS },
+		{ "/share-list",		IdxShareList },
 	};
 
 	FS_LOG(UI, DEBUG) << "Internal path changed to '" << wApp->internalPath() << "'";
@@ -149,6 +152,7 @@ FileShelterApplication::initialize()
 	mainStack->addNew<ShareDownload>();
 	mainStack->addNew<ShareEdit>();
 	mainStack->addWidget(createTermsOfService());
+	mainStack->addNew<ShareList>();
 
 	internalPathChanged().connect(mainStack, [mainStack]
 	{

--- a/src/fileshelter/ui/PasswordUtils.cpp
+++ b/src/fileshelter/ui/PasswordUtils.cpp
@@ -53,4 +53,30 @@ namespace UserInterface::PasswordUtils
 		return res;
 	}
 
+	bool
+	isListPasswordDefined()
+	{
+		bool hasStrings {};
+		Service<IConfig>::get()->visitStrings("list-passwords", [&](std::string_view str)
+		{
+			if (!str.empty())
+				hasStrings = true;
+		});
+
+		return hasStrings;
+	}
+
+	bool
+	checkListPassword(std::string_view listPassword)
+	{
+		bool res{};
+		Service<IConfig>::get()->visitStrings("list-passwords", [&](std::string_view password)
+		{
+			if (password == listPassword)
+				res = true;
+		});
+
+		return res;
+	}
+
 }

--- a/src/fileshelter/ui/ShareList.cpp
+++ b/src/fileshelter/ui/ShareList.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2016 Emeric Poupon
+ *
+ * This file is part of fileshelter.
+ *
+ * fileshelter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * fileshelter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with fileshelter.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ShareList.hpp"
+
+#include <Wt/WAnchor.h>
+#include <Wt/WPushButton.h>
+#include <Wt/WTemplate.h>
+
+#include "resources/ShareResource.hpp"
+#include "share/IShareManager.hpp"
+#include "share/Exception.hpp"
+#include "share/Types.hpp"
+#include "utils/Logger.hpp"
+#include "utils/Service.hpp"
+
+#include "PasswordUtils.hpp"
+#include "Exception.hpp"
+#include "ShareListPassword.hpp"
+#include "ShareUtils.hpp"
+
+namespace UserInterface
+{
+
+	ShareList::ShareList()
+	{
+		wApp->internalPathChanged().connect(this, [this]
+		{
+			handlePathChanged();
+		});
+
+		handlePathChanged();
+	}
+
+	void
+	ShareList::handlePathChanged()
+	{
+		clear();
+
+		if (!wApp->internalPathMatches("/share-list"))
+			return;
+
+		if (!PasswordUtils::isListPasswordDefined())
+			return;
+		else
+			displayPassword();
+	}
+
+	void
+	ShareList::displayPassword()
+	{
+		auto view = addNew<ShareListPassword>();
+		view->success().connect([=]
+		{
+			clear();
+			displayList();
+		});
+	}
+
+	void
+	ShareList::displayList()
+	{
+		Wt::WTemplate* t {addNew<Wt::WTemplate>(tr("template-share-list"))};
+
+		t->addFunction("tr", &Wt::WTemplate::Functions::tr);
+
+		auto* sharesContainer {t->bindNew<Wt::WContainerWidget>("shares")};
+
+		std::size_t nbShares{0};
+		Service<Share::IShareManager>::get()->visitShares([&](const Share::ShareDesc& share)
+		{
+			nbShares++;
+
+			Wt::WTemplate* shareTemplate {sharesContainer->addNew<Wt::WTemplate>(tr("template-share-list-file"))};
+
+			shareTemplate->bindString("share-uuid", share.uuid.toString());
+			shareTemplate->bindString("expiry-date-time", share.expiryTime.toString() + " UTC", Wt::TextFormat::Plain);
+			shareTemplate->bindString("share-size", ShareUtils::fileSizeToString(share.size), Wt::TextFormat::Plain);
+			shareTemplate->bindInt("download-count", share.readCount);
+			shareTemplate->bindString("created-by", share.creatorAddress);
+		});
+		t->bindInt("total-shares", nbShares);
+	}
+
+} // namespace UserInterface

--- a/src/fileshelter/ui/ShareList.hpp
+++ b/src/fileshelter/ui/ShareList.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Emeric Poupon
+ * Copyright (C) 2016 Emeric Poupon
  *
  * This file is part of fileshelter.
  *
@@ -19,12 +19,21 @@
 
 #pragma once
 
-#include <string_view>
+#include <Wt/WContainerWidget.h>
 
-namespace UserInterface::PasswordUtils
+namespace UserInterface
 {
-	bool isUploadPassordRequired();
-	bool checkUploadPassord(std::string_view uploadPassword);
-    bool isListPasswordDefined();
-    bool checkListPassword(std::string_view listPassword);
-}
+
+    class ShareList : public Wt::WContainerWidget
+    {
+        public:
+            ShareList();
+
+        private:
+            void handlePathChanged();
+
+            void displayPassword();
+            void displayList();
+    };
+
+} // namespace UserInterface

--- a/src/fileshelter/ui/ShareListPassword.cpp
+++ b/src/fileshelter/ui/ShareListPassword.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2016 Emeric Poupon
+ *
+ * This file is part of fileshelter.
+ *
+ * fileshelter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * fileshelter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with fileshelter.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ShareListPassword.hpp"
+
+#include <thread>
+#include <Wt/WFormModel.h>
+#include <Wt/WLineEdit.h>
+#include <Wt/WPushButton.h>
+
+#include "utils/Logger.hpp"
+#include "PasswordUtils.hpp"
+
+namespace UserInterface
+{
+
+	class ShareListPasswordValidator : public Wt::WValidator
+	{
+		public:
+			ShareListPasswordValidator(Wt::WObject *parent = 0)
+				: Wt::WValidator(parent)
+			{
+				setMandatory(true);
+			}
+
+			Result validate(const Wt::WString& input) const override
+			{
+				auto res {Wt::WValidator::validate(input)};
+				if (res.state() != Wt::ValidationState::Valid)
+					return res;
+
+				if (PasswordUtils::checkListPassword(input.toUTF8()))
+					return Result {Wt::ValidationState::Valid};
+
+				return Result {Wt::ValidationState::Invalid, Wt::WString::tr("msg-bad-password")};
+			}
+	};
+
+	class ShareListPasswordFormModel : public Wt::WFormModel
+	{
+		public:
+			static const Field PasswordField;
+
+			ShareListPasswordFormModel()
+			{
+				addField(PasswordField);
+
+				setValidator(PasswordField, std::make_unique<ShareListPasswordValidator>());
+			}
+	};
+
+	const Wt::WFormModel::Field ShareListPasswordFormModel::PasswordField = "password";
+
+	ShareListPassword::ShareListPassword()
+	{
+		auto model = std::make_shared<ShareListPasswordFormModel>();
+
+		setTemplateText(tr("template-share-list-password"));
+		addFunction("id", &WTemplate::Functions::id);
+		addFunction("block", &WTemplate::Functions::block);
+
+		// Password
+		auto password = std::make_unique<Wt::WLineEdit>();
+		password->setEchoMode(Wt::EchoMode::Password);
+		setFormWidget(ShareListPasswordFormModel::PasswordField, std::move(password));
+
+		// Buttons
+		Wt::WPushButton *unlockBtn = bindNew<Wt::WPushButton>("unlock-btn", tr("msg-unlock"));
+		unlockBtn->clicked().connect([=]
+		{
+			updateModel(model.get());
+
+			if (model->validate())
+			{
+				FS_LOG(UI, DEBUG) << "List password validation OK";
+				success().emit();
+				return;
+			}
+
+			FS_LOG(UI, DEBUG) << "List password validation failed";
+
+			// Mitigate brute force attemps
+			// TODO per peer/share
+			std::this_thread::sleep_for(std::chrono::seconds {1});
+
+			updateView(model.get());
+		});
+
+		updateView(model.get());
+	}
+
+} // namespace UserInterface

--- a/src/fileshelter/ui/ShareListPassword.hpp
+++ b/src/fileshelter/ui/ShareListPassword.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Emeric Poupon
+ * Copyright (C) 2016 Emeric Poupon
  *
  * This file is part of fileshelter.
  *
@@ -19,12 +19,20 @@
 
 #pragma once
 
-#include <string_view>
+#include <Wt/WSignal.h>
+#include <Wt/WTemplateFormView.h>
 
-namespace UserInterface::PasswordUtils
+namespace UserInterface
 {
-	bool isUploadPassordRequired();
-	bool checkUploadPassord(std::string_view uploadPassword);
-    bool isListPasswordDefined();
-    bool checkListPassword(std::string_view listPassword);
-}
+    class ShareListPassword : public Wt::WTemplateFormView
+    {
+        public:
+            Wt::Signal<>& success() { return _sigSuccess;}
+
+            ShareListPassword();
+
+        private:
+            Wt::Signal<> _sigSuccess;
+    };
+
+} // namespace UserInterface


### PR DESCRIPTION
Add /share-list URL if "list-passwords" param is set. Display a simple list of active shares.