### PR TITLE
Issue 097 - Fix https download link showing as http text behind nginx reverse proxy

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,22 +18,22 @@ As root, trust the following debian package provider and add it in your list of 
 wget https://debian.poupon.dev/apt/debian/epoupon.gpg -P /usr/share/keyrings
 echo "deb [signed-by=/usr/share/keyrings/epoupon.gpg] https://debian.poupon.dev/apt/debian bookworm main" > /etc/apt/sources.list.d/epoupon.list
 ```
-To install or upgrade _fileshelter_:
+To install or upgrade _Fileshelter_:
 ```sh
 apt update
 apt install fileshelter
 ```
-The _fileshelter_ service is started just after the package installation, run by a dedicated _fileshelter_ system user.</br>
+The `fileshelter` service is started just after the package installation, run by a dedicated `fileshelter` system user.</br>
 Please refer to [Deployment](#deployment) for further configuration options.
 ## From source
 __Note__: this installation process and the default values of the configuration files have been written for _Debian Bookworm_. Therefore, you may have to adapt commands and/or paths in order to fit to your distribution.
 ### Debian/Ubuntu dependencies
-__Note__: a C++17 compiler is needed to compile _fileshelter_
+__Note__: a C++17 compiler is needed to compile _Fileshelter_
 ```sh
-apt-get install build-essential cmake libboost-dev libconfig++-dev
+apt-get install build-essential cmake libboost-dev libconfig++-dev libarchive-dev
 ```
 
-You also need _Wt4_, that is not packaged yet on _Debian_. See [installation instructions](https://www.webtoolkit.eu/wt/doc/reference/html/InstallationUnix.html).
+You also need _Wt4_, that is not packaged on _Debian_. See [installation instructions](https://www.webtoolkit.eu/wt/doc/reference/html/InstallationUnix.html).
 
 ### Build
 ```sh
@@ -71,7 +71,7 @@ cp /usr/share/fileshelter/fileshelter.conf /etc/fileshelter.conf
 cp /usr/share/fileshelter/fileshelter.service /lib/systemd/system/fileshelter.service
 ```
 
-Create the working directory and give it access to the _fileshelter_ user:
+Create the working directory and give it access to the `fileshelter` user:
 ```sh
 mkdir /var/fileshelter
 chown -R fileshelter:fileshelter /var/fileshelter
@@ -103,13 +103,16 @@ systemctl restart fileshelter
 ## Configuration
 _Fileshelter_ uses a configuration file, installed by default in `/etc/fileshelter.conf`. It is recommended to edit this file and change relevant settings (listen address, listen port, working directory, ...).
 
-A basic _Terms of Services_ is provided. The configuration file contains the definition of the fields needed by the default tos.
-You may also specify an alternate tos file to fit your needs.
+A basic _Terms of Service_ is provided. The configuration file contains the definition of the fields needed by the default ToS.
+You may also specify an alternate ToS file to fit your needs.
 
 If a setting is not present in the configuration file, a hardcoded default value is used (the same as in the [default.conf](conf/fileshelter.conf) file)
 
 ## Reverse proxy settings
-_Fileshelter_ is shipped with an embedded web server, but it is recommended to deploy behind a reverse proxy. You have to set the _behind-reverse-proxy_ option to _true_ in the `fileshelter.conf` configuration file.
+_Fileshelter_ is shipped with an embedded web server, but it is recommended to deploy behind a reverse proxy.
+You have to set the `behind-reverse-proxy` option to `true` in the `fileshelter.conf` configuration file and to adjust the trusted proxy list in `trusted-proxies`.
+
+__Note__: when running in a docker environment, you have to trust the docker gateway IP (which is `172.17.0.1` by default)
 
 Here is an example to make _Fileshelter_ properly work on _myserver.org_ using _nginx_:
 ```
@@ -143,7 +146,7 @@ server {
 systemctl start fileshelter
 ```
 
-Log traces can be accessed using journactl:
+Logs can be accessed using `journalctl`:
 ```sh
 journalctl -u fileshelter.service
 ```

--- a/src/fileshelter/main/main.cpp
+++ b/src/fileshelter/main/main.cpp
@@ -57,7 +57,7 @@ std::vector<std::string> generateWtConfig(std::string execPath)
 
 	if (Service<IConfig>::get()->getBool("tls-enable", false))
 	{
-		args.push_back("--https-port=" + std::to_string( Service<IConfig>::get()->getULong("listen-port", 5081)));
+		args.push_back("--https-port=" + std::to_string( Service<IConfig>::get()->getULong("listen-port", 5091)));
 		args.push_back("--https-address=" + std::string {Service<IConfig>::get()->getString("listen-addr", "0.0.0.0")});
 		args.push_back("--ssl-certificate=" + std::string {Service<IConfig>::get()->getString("tls-cert")});
 		args.push_back("--ssl-private-key=" + std::string {Service<IConfig>::get()->getString("tls-key")});
@@ -65,7 +65,7 @@ std::vector<std::string> generateWtConfig(std::string execPath)
 	}
 	else
 	{
-		args.push_back("--http-port=" + std::to_string( Service<IConfig>::get()->getULong("listen-port", 5081)));
+		args.push_back("--http-port=" + std::to_string( Service<IConfig>::get()->getULong("listen-port", 5091)));
 		args.push_back("--http-address=" + std::string {Service<IConfig>::get()->getString("listen-addr", "0.0.0.0")});
 	}
 

--- a/src/fileshelter/ui/ShareCreatePassword.cpp
+++ b/src/fileshelter/ui/ShareCreatePassword.cpp
@@ -69,20 +69,9 @@ namespace UserInterface
 
 	ShareCreatePassword::ShareCreatePassword()
 	{
-		auto model = std::make_shared<ShareCreatePasswordFormModel>();
+		auto model {std::make_shared<ShareCreatePasswordFormModel>()};
 
-		setTemplateText(tr("template-share-create-password"));
-		addFunction("id", &WTemplate::Functions::id);
-		addFunction("block", &WTemplate::Functions::block);
-
-		// Password
-		auto password = std::make_unique<Wt::WLineEdit>();
-		password->setEchoMode(Wt::EchoMode::Password);
-		setFormWidget(ShareCreatePasswordFormModel::PasswordField, std::move(password));
-
-		// Buttons
-		Wt::WPushButton* unlockBtn {bindNew<Wt::WPushButton>("unlock-btn", tr("msg-unlock"))};
-		unlockBtn->clicked().connect([=]
+		auto validateForm {[this, model]
 		{
 			updateModel(model.get());
 
@@ -100,7 +89,21 @@ namespace UserInterface
 			std::this_thread::sleep_for(std::chrono::seconds {1});
 
 			updateView(model.get());
-		});
+		}};
+
+		setTemplateText(tr("template-share-create-password"));
+		addFunction("id", &WTemplate::Functions::id);
+		addFunction("block", &WTemplate::Functions::block);
+
+		// Password
+		auto password = std::make_unique<Wt::WLineEdit>();
+		password->setEchoMode(Wt::EchoMode::Password);
+		password->enterPressed().connect([=]{ validateForm(); });
+		setFormWidget(ShareCreatePasswordFormModel::PasswordField, std::move(password));
+
+		// Buttons
+		Wt::WPushButton* unlockBtn {bindNew<Wt::WPushButton>("unlock-btn", tr("msg-unlock"))};
+		unlockBtn->clicked().connect([=] { validateForm(); });
 
 		updateView(model.get());
 	}

--- a/src/fileshelter/ui/ShareDownloadPassword.cpp
+++ b/src/fileshelter/ui/ShareDownloadPassword.cpp
@@ -91,18 +91,7 @@ namespace UserInterface
 	{
 		auto model {std::make_shared<ShareDownloadPasswordFormModel>(shareUUID)};
 
-		setTemplateText(tr("template-share-download-password"));
-		addFunction("id", &WTemplate::Functions::id);
-		addFunction("block", &WTemplate::Functions::block);
-
-		// Password
-		auto password = std::make_unique<Wt::WLineEdit>();
-		password->setEchoMode(Wt::EchoMode::Password);
-		setFormWidget(ShareDownloadPasswordFormModel::PasswordField, std::move(password));
-
-		// Buttons
-		Wt::WPushButton *unlockBtn = bindNew<Wt::WPushButton>("unlock-btn", tr("msg-unlock"));
-		unlockBtn->clicked().connect([=]
+		auto validateForm {[this, model]
 		{
 			updateModel(model.get());
 
@@ -117,7 +106,21 @@ namespace UserInterface
 			FS_LOG(UI, DEBUG) << "Download password validation failed";
 
 			updateView(model.get());
-		});
+		}};
+
+		setTemplateText(tr("template-share-download-password"));
+		addFunction("id", &WTemplate::Functions::id);
+		addFunction("block", &WTemplate::Functions::block);
+
+		// Password
+		auto password = std::make_unique<Wt::WLineEdit>();
+		password->setEchoMode(Wt::EchoMode::Password);
+		password->enterPressed().connect([=]{ validateForm(); });
+		setFormWidget(ShareDownloadPasswordFormModel::PasswordField, std::move(password));
+
+		// Buttons
+		Wt::WPushButton *unlockBtn = bindNew<Wt::WPushButton>("unlock-btn", tr("msg-unlock"));
+		unlockBtn->clicked().connect([=] { validateForm(); });
 
 		updateView(model.get());
 	}

--- a/src/fileshelter/ui/ShareUtils.cpp
+++ b/src/fileshelter/ui/ShareUtils.cpp
@@ -31,6 +31,8 @@ namespace UserInterface::ShareUtils
     std::string
     getScheme()
     {
+        // Necessary because the scheme in envonment does not pay attention to X-Forwarded_Proto by default
+        //and we have to use that beause you cannot get the full URL out of wLink as text
         const std::string xForwardedProto = wApp->environment().headerValue("X-Forwarded-Proto");
         if (!xForwardedProto.empty())
         {

--- a/src/fileshelter/ui/ShareUtils.cpp
+++ b/src/fileshelter/ui/ShareUtils.cpp
@@ -40,7 +40,7 @@ namespace UserInterface::ShareUtils
         }
 
         // Fallback if header is not set
-        return "http";
+        return wApp->environment().urlScheme();
     }
     
 	static

--- a/src/fileshelter/ui/ShareUtils.cpp
+++ b/src/fileshelter/ui/ShareUtils.cpp
@@ -26,12 +26,26 @@
 
 namespace UserInterface::ShareUtils
 {
+    
+    static
+    std::string
+    getScheme()
+    {
+        const std::string xForwardedProto = wApp->environment().getHeaderValue("X-Forwarded-Proto");
+        if (!xForwardedProto.empty())
+        {
+            return xForwardedProto;  // will be 'http' or 'https'
+        }
 
+        // Fallback if header is not set
+        return "http";
+    }
+    
 	static
 	std::string
 	computeURL(const std::string& internalPath)
 	{
-		return wApp->environment().urlScheme() + "://" + wApp->environment().hostName() + (wApp->environment().deploymentPath() == "/" ? "" : wApp->environment().deploymentPath()) + internalPath;
+		return getScheme() + "://" + wApp->environment().hostName() + (wApp->environment().deploymentPath() == "/" ? "" : wApp->environment().deploymentPath()) + internalPath;
 	}
 
 	std::unique_ptr<Wt::WAnchor>

--- a/src/fileshelter/ui/ShareUtils.cpp
+++ b/src/fileshelter/ui/ShareUtils.cpp
@@ -31,7 +31,7 @@ namespace UserInterface::ShareUtils
     std::string
     getScheme()
     {
-        const std::string xForwardedProto = wApp->environment().getHeaderValue("X-Forwarded-Proto");
+        const std::string xForwardedProto = wApp->environment().HeaderValue("X-Forwarded-Proto");
         if (!xForwardedProto.empty())
         {
             return xForwardedProto;  // will be 'http' or 'https'

--- a/src/fileshelter/ui/ShareUtils.cpp
+++ b/src/fileshelter/ui/ShareUtils.cpp
@@ -31,7 +31,7 @@ namespace UserInterface::ShareUtils
     std::string
     getScheme()
     {
-        const std::string xForwardedProto = wApp->environment().HeaderValue("X-Forwarded-Proto");
+        const std::string xForwardedProto = wApp->environment().headerValue("X-Forwarded-Proto");
         if (!xForwardedProto.empty())
         {
             return xForwardedProto;  // will be 'http' or 'https'


### PR DESCRIPTION
Fixed the display text of the links created  - see https://github.com/epoupon/fileshelter/issues/97

I _think_ I have created the branch andy (which I should have given a better name) off develop, made changes just for #97. Let me know how I did!

I have followed the same syntax conventions as the rest of the code, tested it and it all seems good.

Not sure what else is outstanding on develop but this should be easy enough to pull into the master and release, if you are happy with it.