### PR TITLE
use cmake libdir & http[s]-listen

### DIFF
--- a/conf/fileshelter.conf
+++ b/conf/fileshelter.conf
@@ -31,9 +31,8 @@ upload-passwords =
 (
 );
 
-# Listen port/addr of the web server
-listen-port = 5091;
-listen-addr = "0.0.0.0";
+# Listen addr:port or hostname:port of the web server
+listen = "0.0.0.0:5091";
 behind-reverse-proxy = false;
 # original-ip-header and trusted-proxies are used only if behind-reverse-proxy is set to true
 original-ip-header = "X-Forwarded-For";

--- a/src/fileshelter/main/main.cpp
+++ b/src/fileshelter/main/main.cpp
@@ -57,16 +57,14 @@ std::vector<std::string> generateWtConfig(std::string execPath)
 
 	if (Service<IConfig>::get()->getBool("tls-enable", false))
 	{
-		args.push_back("--https-port=" + std::to_string( Service<IConfig>::get()->getULong("listen-port", 5091)));
-		args.push_back("--https-address=" + std::string {Service<IConfig>::get()->getString("listen-addr", "0.0.0.0")});
+		args.push_back("--https-listen=" + std::string {Service<IConfig>::get()->getString("listen", "0.0.0.0:5091")});
 		args.push_back("--ssl-certificate=" + std::string {Service<IConfig>::get()->getString("tls-cert")});
 		args.push_back("--ssl-private-key=" + std::string {Service<IConfig>::get()->getString("tls-key")});
 		args.push_back("--ssl-tmp-dh=" + std::string {Service<IConfig>::get()->getString("tls-dh")});
 	}
 	else
 	{
-		args.push_back("--http-port=" + std::to_string( Service<IConfig>::get()->getULong("listen-port", 5091)));
-		args.push_back("--http-address=" + std::string {Service<IConfig>::get()->getString("listen-addr", "0.0.0.0")});
+		args.push_back("--http-listen=" + std::string {Service<IConfig>::get()->getString("listen", "0.0.0.0:5091")});
 	}
 
 	{

--- a/src/libs/share/CMakeLists.txt
+++ b/src/libs/share/CMakeLists.txt
@@ -28,5 +28,5 @@ target_link_libraries(filesheltershare PUBLIC
 	Wt::Wt
 	)
 
-install(TARGETS filesheltershare DESTINATION lib)
+install(TARGETS filesheltershare DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/src/libs/utils/CMakeLists.txt
+++ b/src/libs/utils/CMakeLists.txt
@@ -27,5 +27,5 @@ target_link_libraries(fileshelterutils PUBLIC
 	Wt::Wt
 	)
 
-install(TARGETS fileshelterutils DESTINATION lib)
+install(TARGETS fileshelterutils DESTINATION ${CMAKE_INSTALL_LIBDIR})
 


### PR DESCRIPTION
use cmake libdir :
to satisfy some sanity checks

use --http[s]-listen instead of older style --http[s]-address/port :
Benefit of using a hostname or IP address instead of only an IP address, so bind to IPv4 and IPv6 for example.