### PR TITLE
Don't install static libraries

### DIFF
--- a/src/libs/share/CMakeLists.txt
+++ b/src/libs/share/CMakeLists.txt
@@ -27,5 +27,3 @@ target_link_libraries(filesheltershare PUBLIC
 	Wt::Wt
 	)
 
-install(TARGETS filesheltershare DESTINATION ${CMAKE_INSTALL_LIBDIR})
-

--- a/src/libs/utils/CMakeLists.txt
+++ b/src/libs/utils/CMakeLists.txt
@@ -26,5 +26,3 @@ target_link_libraries(fileshelterutils PUBLIC
 	Wt::Wt
 	)
 
-install(TARGETS fileshelterutils DESTINATION ${CMAKE_INSTALL_LIBDIR})
-


### PR DESCRIPTION
Correct me if I'm wrong, but I think installing the static libraries not required. I guess the install commands are just left over from when there was the switch to static libraries? Or are these meant to be used for anything?